### PR TITLE
Improvements - DevSkiller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+seccomp-load
+unit-tests/unit-tests

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CFLAGS = -O2 -Wall -Werror
 
 SECCOMP_SOURCES = seccomp.c seccomp.h main.c
 
-CHECK_SOURCES = unit-tests/unit-tests.c
+CHECK_SOURCES = unit-tests/unit-tests.c seccomp.c
 CHECK_INCLUDES = $(shell pkg-config --cflags glib-2.0) -I.
 CHECK_LIBS = $(shell pkg-config --libs glib-2.0)
 

--- a/main.c
+++ b/main.c
@@ -13,7 +13,7 @@ int main(int argc, char **argv) {
 	const char *profile_path = argv[1];
 	FILE *file  = sc_must_read_and_validate_header_from_file(profile_path, &hdr);
 	sc_must_read_filter_from_file(file, hdr.len_filter, &prog_allow);
-
-
 	sc_apply_seccomp_filter(&prog_allow);
+        fclose(file);
+        fprintf(stderr, "filter loaded okay");
 }

--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@ int main(int argc, char **argv) {
 	sc_apply_seccomp_filter(&prog_allow);
 	free(prog_allow.filter);
 	fclose(file);
-	fprintf(stderr, "filter loaded okay");
+	fprintf(stdout, "filter loaded okay\n");
 
 	return 0;
 }

--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-
+#include <stdlib.h>
 
 #include "seccomp.h"
 
@@ -16,4 +16,6 @@ int main(int argc, char **argv) {
 
 
 	sc_apply_seccomp_filter(&prog_allow);
+	free(prog_allow.filter);
+	fclose(file);
 }

--- a/seccomp.c
+++ b/seccomp.c
@@ -41,13 +41,20 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 	if (num_read < sizeof(struct sc_seccomp_file_header)) {
 		die("short read on seccomp header: %zu", num_read);
 	}
+	// check everything
+	if (hdr->header[0] != 'S' || hdr->header[1] != 'C') {
+		die("unexpected seccomp header: %x%x", hdr->header[0], hdr->header[1]);
+	}
+	if (hdr->len_filter > MAX_BPF_SIZE) {
+		die("allow filter size too big %u", hdr->len_filter);
+	}
 	return file;
 }
 
 void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes, struct sock_fprog *prog)
 {
 	prog->len = len_bytes / sizeof(struct sock_filter);
-	prog->filter = (struct sock_filter *)malloc(MAX_BPF_SIZE);
+	prog->filter = (struct sock_filter *)malloc(len_bytes);
 	if (prog->filter == NULL) {
 		die("cannot allocate %u bytes of memory for seccomp filter ", len_bytes);
 	}

--- a/seccomp.c
+++ b/seccomp.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#include <inttypes.h>
+
 
 #include <sys/prctl.h>
 #include <sys/stat.h>
@@ -46,8 +48,18 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 
 void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes, struct sock_fprog *prog)
 {
-	prog->len = len_bytes / sizeof(struct sock_filter);
-	prog->filter = (struct sock_filter *)malloc(MAX_BPF_SIZE);
+	if((len_bytes % sizeof(struct sock_filter)) != 0) {
+		die("filter size %" PRIu32 " not a multiple of sock_filter size %zu", len_bytes, sizeof(struct sock_filter));
+	}
+
+	size_t num_filter_blocks = len_bytes / sizeof(struct sock_filter);
+	if(num_filter_blocks > USHRT_MAX) {
+		// sock_fprog.len is of type unsigned short
+		die("filter size too large");
+	}
+
+	prog->len = num_filter_blocks;
+	prog->filter = (struct sock_filter *)malloc(len_bytes);
 	if (prog->filter == NULL) {
 		die("cannot allocate %u bytes of memory for seccomp filter ", len_bytes);
 	}

--- a/seccomp.c
+++ b/seccomp.c
@@ -18,8 +18,6 @@
 
 #include "seccomp.h"
 
-#define MAX_BPF_SIZE 32*1024
-
 void die(const char *msg, ...)
 {
 	va_list ap;
@@ -54,6 +52,7 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 		die("unexpected seccomp header: %x%x", hdr->header[0], hdr->header[1]);
 	}
 	if (hdr->len_filter > MAX_BPF_SIZE) {
+		fclose(file);
 		die("allow filter size too big %u", hdr->len_filter);
 	}
 	return file;

--- a/seccomp.c
+++ b/seccomp.c
@@ -43,6 +43,13 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 	if (num_read < sizeof(struct sc_seccomp_file_header)) {
 		die("short read on seccomp header: %zu", num_read);
 	}
+
+	if(!(hdr->header[0] == 'S' &&
+		hdr->header[1] == 'C' &&
+		hdr->version == 0x01
+	)) {
+		die("unsupported seccomp file header or version");
+	}
 	return file;
 }
 

--- a/seccomp.c
+++ b/seccomp.c
@@ -38,9 +38,11 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 	}
 	size_t num_read = fread(hdr, 1, sizeof(struct sc_seccomp_file_header), file);
 	if (ferror(file) != 0) {
+		fclose(file);
 		die("cannot read seccomp profile %s", profile_path);
 	}
 	if (num_read < sizeof(struct sc_seccomp_file_header)) {
+		fclose(file);
 		die("short read on seccomp header: %zu", num_read);
 	}
 
@@ -48,6 +50,7 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 		hdr->header[1] == 'C' &&
 		hdr->version == 0x01
 	)) {
+		fclose(file);
 		die("unsupported seccomp file header or version");
 	}
 	return file;
@@ -56,25 +59,32 @@ FILE* sc_must_read_and_validate_header_from_file(const char *profile_path, struc
 void sc_must_read_filter_from_file(FILE *file, uint32_t len_bytes, struct sock_fprog *prog)
 {
 	if((len_bytes % sizeof(struct sock_filter)) != 0) {
+		fclose(file);
 		die("filter size %" PRIu32 " not a multiple of sock_filter size %zu", len_bytes, sizeof(struct sock_filter));
 	}
 
 	size_t num_filter_blocks = len_bytes / sizeof(struct sock_filter);
 	if(num_filter_blocks > USHRT_MAX) {
 		// sock_fprog.len is of type unsigned short
+		fclose(file);
 		die("filter size too large");
 	}
 
 	prog->len = num_filter_blocks;
 	prog->filter = (struct sock_filter *)malloc(len_bytes);
 	if (prog->filter == NULL) {
+		fclose(file);
 		die("cannot allocate %u bytes of memory for seccomp filter ", len_bytes);
 	}
 	size_t num_read = fread(prog->filter, 1, len_bytes, file);
 	if (ferror(file)) {
+		fclose(file);
+		free(prog->filter);
 		die("cannot read filter");
 	}
 	if (num_read != len_bytes) {
+		fclose(file);
+		free(prog->filter);
 		die("short read for filter %zu != %i", num_read, len_bytes);
 	}
 }
@@ -87,6 +97,7 @@ int seccomp(unsigned int operation, unsigned int flags, void *args) {
 void sc_apply_seccomp_filter(struct sock_fprog *prog) {
 	int err = seccomp(SECCOMP_SET_MODE_FILTER, SECCOMP_FILTER_FLAG_LOG, prog);
 	if (err != 0) {
+		free(prog->filter);
 		die("cannot apply seccomp profile");
 	}
 }

--- a/seccomp.h
+++ b/seccomp.h
@@ -7,9 +7,13 @@
 
 #include <linux/filter.h>
 
+
 struct sc_seccomp_file_header {
+	// must be 'S', 'C'
 	char header[2];
+	// must be 0x1
 	uint8_t version;
+	// only 0x0 or 0x1 support right now
 	uint8_t unrestricted;
 
 	uint32_t len_filter;
@@ -23,3 +27,4 @@ void sc_apply_seccomp_filter(struct sock_fprog *prog);
 void die(const char *fmt, ...);
 
 #endif
+

--- a/seccomp.h
+++ b/seccomp.h
@@ -8,7 +8,9 @@
 #include <linux/filter.h>
 
 struct sc_seccomp_file_header {
+	// Magic bytes 'S', 'C'
 	char header[2];
+	// Currently only 0x01 is supported
 	uint8_t version;
 	uint8_t unrestricted;
 

--- a/seccomp.h
+++ b/seccomp.h
@@ -1,5 +1,5 @@
 #ifndef X_SECCOMP_H
-#define X_SUPPORT_H
+#define X_SECCOMP_H
 
 
 #include <stdio.h>

--- a/seccomp.h
+++ b/seccomp.h
@@ -7,6 +7,7 @@
 
 #include <linux/filter.h>
 
+#define MAX_BPF_SIZE 32*1024
 
 struct sc_seccomp_file_header {
 	// must be 'S', 'C'

--- a/unit-tests/unit-tests.c
+++ b/unit-tests/unit-tests.c
@@ -27,10 +27,32 @@ static void test_must_read_and_validate_header_from_file__happy(void)
 	g_assert_true(file != NULL);
 }
 
+static void test_must_read_and_validate_header_from_file__missing_header(void)
+{
+	struct sc_seccomp_file_header hdr = {};
+
+	if (g_test_subprocess()) {
+		char *profile = NULL;
+		int fd = 0;
+		make_seccomp_profile(&hdr, &fd, &profile);
+		FILE *file = sc_must_read_and_validate_header_from_file(profile, &hdr);
+		g_assert_not_reached();
+		// check null
+		g_assert_null(file);
+	}
+
+	g_test_trap_subprocess(NULL, 0, 0);
+	g_test_trap_assert_failed();
+	g_test_trap_assert_stderr("unexpected seccomp header: 00\n");
+}
+
 static void __attribute__((constructor)) init(void)
 {
 	g_test_add_func("/seccomp/must_read_and_validate_header_from_file/happy",
 	     test_must_read_and_validate_header_from_file__happy);
+	g_test_add_func("/seccomp/must_read_and_validate_header_from_file/missing_header",
+	     test_must_read_and_validate_header_from_file__missing_header);
+
 }
 
 int main(int argc, char **argv)

--- a/unit-tests/unit-tests.c
+++ b/unit-tests/unit-tests.c
@@ -1,6 +1,9 @@
 #include <glib.h>
+#include <unistd.h>
 
-#include "seccomp.c"
+#include "seccomp.h"
+
+#define UNUSED(x) (void)(x)
 
 static void make_seccomp_profile(struct sc_seccomp_file_header *hdr, int *fd,
 				 char **fname)
@@ -17,6 +20,7 @@ static void test_must_read_and_validate_header_from_file__happy(void)
 		.header[0] = 'S',
 		.header[1] = 'C',
 		.version = 1,
+		.unrestricted = 0,
 	};
 	char *profile = NULL;
 	int fd = 0;
@@ -25,6 +29,9 @@ static void test_must_read_and_validate_header_from_file__happy(void)
 	FILE *file =
 	    sc_must_read_and_validate_header_from_file(profile, &hdr);
 	g_assert_true(file != NULL);
+
+	free(profile);
+	fclose(file);
 }
 
 static void test_must_read_and_validate_header_from_file__missing_header(void)
@@ -36,9 +43,8 @@ static void test_must_read_and_validate_header_from_file__missing_header(void)
 		int fd = 0;
 		make_seccomp_profile(&hdr, &fd, &profile);
 		FILE *file = sc_must_read_and_validate_header_from_file(profile, &hdr);
+		UNUSED(file);
 		g_assert_not_reached();
-		// check null
-		g_assert_null(file);
 	}
 
 	g_test_trap_subprocess(NULL, 0, 0);


### PR DESCRIPTION
- Merged changes from the original `improve` branch
    - Bugfixes and improvements made in the merged test files
- Freed resources after use and before each `die` is called
- Added `.gitignore` for built files
- Added checks for supported seccomp file headers
- Improvements in `sc_must_read_filter_from_file()`
    - `len_bytes` must now be an integer multiple of `sizeof(struct sock_filter)`
    - Added overflow checks when assigning to `prog->len` (type unsigned short)
- Fixed `seccomp.h` header guard